### PR TITLE
added simple file for build it with PlatformIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch
+
+# Vim backups
+*.swp
+
+.vscode

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,58 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[common_env_data]
+framework = arduino
+upload_speed = 1500000
+monitor_speed = 115200
+build_flags =
+  -Os 
+  -DUSER_SETUP_LOADED=1
+  -DST7789_DRIVER=1
+  -DENABLE_TFT=1
+  -DTFT_WIDTH=135
+  -DTFT_HEIGHT=240
+  -DCGRAM_OFFSET=1     ; Library will add offsets required
+  -DTFT_MOSI=19
+  -DTFT_SCLK=18
+  -DTFT_CS=5
+  -DTFT_DC=16
+  -DTFT_RST=23
+  -DTFT_BL=4           ; Display backlight control pin
+  -DTFT_BACKLIGHT_ON=1 ; HIGH or LOW are options
+  -DLOAD_GLCD=1
+  -DLOAD_FONT2=1
+  -DLOAD_FONT4=1
+  -DLOAD_FONT6=1
+  -DLOAD_FONT7=1
+  -DLOAD_FONT8=1
+  -DLOAD_GFXFF=1
+  -DSMOOTH_FONT=1
+  -DSPI_FREQUENCY=40000000     ; Maximum for ILI9341
+  -DSPI_READ_FREQUENCY=6000000 ; 6 MHz is the maximum SPI read speed for the ST7789V
+  -DCORE_DEBUG_LEVEL=3         ; Info level for development, please comment it for production
+
+lib_deps =
+  bodmer/TFT_eSPI @ ^2.2.20
+  ArduinoJson @ 6.17.2
+  https://github.com/taranais/NTPClient.git
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = ${common_env_data.framework}
+upload_speed = ${common_env_data.upload_speed}
+monitor_speed = ${common_env_data.monitor_speed}
+build_flags = ${common_env_data.build_flags}
+lib_deps = ${common_env_data.lib_deps}
+


### PR DESCRIPTION
- [x] Added PlatformIO ini file with auto library dependencies and esp32 environment
- [x] Added special NTPClient library fork (it is unnecessary, maybe it should be change for a next PR)
- [x] tested with ESP32 TTGO T-Display

For build it, you only need [PlatformIO CLI or IDE](https://docs.platformio.org/en/latest/integration/ide/vscode.html#installation) installed, and with the next command, it will install all library dependencies, toolchains, etc, for build:

```bash
pio run --target upload
```